### PR TITLE
Fix: build x86_64-apple-darwin on macos-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             archive: tar.gz
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             archive: tar.gz
           - os: ubuntu-latest


### PR DESCRIPTION
## Summary
The first release attempt (v0.1.0) failed because the \`macos-13\` runner is no longer supported by GitHub Actions. Build both macOS targets on \`macos-latest\` (ARM) and rely on rustup's native cross-compile for x86_64-apple-darwin.

The other 3 platform builds (Linux, Windows, ARM Mac) and the VSIX build all succeeded — only the Intel Mac build was the blocker.

## Test plan
- [ ] Re-tag v0.1.0 after merge and confirm all 4 platform builds + VSIX + Release job complete successfully
🤖 Generated with [Claude Code](https://claude.com/claude-code)