### PR TITLE
Fix jaw syntax bleeding past markdown code fence

### DIFF
--- a/editors/vscode/syntaxes/jaw-markdown-injection.json
+++ b/editors/vscode/syntaxes/jaw-markdown-injection.json
@@ -3,12 +3,12 @@
   "injectionSelector": "L:text.html.markdown",
   "patterns": [
     {
-      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(jaw))\\s*$",
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(jaw)(\\s+[^`~]*)?$)",
       "beginCaptures": {
         "3": { "name": "punctuation.definition.markdown" },
         "4": { "name": "fenced_code.block.language.markdown" }
       },
-      "end": "(^|\\G)(\\2)(\\3)\\s*$",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
       "endCaptures": {
         "3": { "name": "punctuation.definition.markdown" }
       },

--- a/editors/vscode/syntaxes/jaw.tmLanguage.json
+++ b/editors/vscode/syntaxes/jaw.tmLanguage.json
@@ -27,7 +27,7 @@
       "beginCaptures": {
         "2": { "name": "comment.line.caret.jaw" }
       },
-      "end": "(?=^\\s*(?:\\[\\d+\\]|\\[\\^\\]|\\[\\*\\]|\\[!\\]|\\[>\\]|\\[~\\]|\\[&\\]|\\[\\+\\]|\\[-\\]|\\[[A-Za-z][A-Za-z0-9_]*\\]\\s*[—:]|/))",
+      "end": "(?=^\\s*(?:\\[\\d+\\]|\\[\\^\\]|\\[\\*\\]|\\[!\\]|\\[>\\]|\\[~\\]|\\[&\\]|\\[\\+\\]|\\[-\\]|\\[[A-Za-z][A-Za-z0-9_]*\\]\\s*[—:]|/|`{3,}|~{3,}))",
       "patterns": [
         { "include": "#comment-variable-reference" },
         { "include": "#comment-function-reference" }
@@ -39,7 +39,7 @@
       "beginCaptures": {
         "2": { "name": "comment.line.asterisk.jaw" }
       },
-      "end": "(?=^\\s*(?:\\[\\d+\\]|\\[\\^\\]|\\[\\*\\]|\\[!\\]|\\[>\\]|\\[~\\]|\\[&\\]|\\[\\+\\]|\\[-\\]|\\[[A-Za-z][A-Za-z0-9_]*\\]\\s*[—:]|/))",
+      "end": "(?=^\\s*(?:\\[\\d+\\]|\\[\\^\\]|\\[\\*\\]|\\[!\\]|\\[>\\]|\\[~\\]|\\[&\\]|\\[\\+\\]|\\[-\\]|\\[[A-Za-z][A-Za-z0-9_]*\\]\\s*[—:]|/|`{3,}|~{3,}))",
       "patterns": [
         { "include": "#comment-variable-reference" },
         { "include": "#comment-function-reference" }
@@ -68,7 +68,7 @@
           ]
         }
       },
-      "end": "(?=^(?!\\s*$)(?!\\1\\s+\\S))",
+      "end": "(?=^\\s*(?:`{3,}|~{3,}))|(?=^(?!\\s*$)(?!\\1\\s+\\S))",
       "contentName": "string.unquoted.log.jaw",
       "patterns": [
         { "include": "#decorator" },


### PR DESCRIPTION
## Summary
- Multi-line `code-comment`, `general-comment`, and `log` patterns used end-lookaheads that only stopped at the next jaw marker, so inside a ` ```jaw ` fence the closing ` ``` ` was consumed and highlighting bled into the rest of the markdown doc.
- Added backtick/tilde fence patterns to the end lookaheads (safe — fences aren't valid jaw syntax).
- Tightened the markdown injection's begin/end to match VS Code's standard fenced-block patterns (allow trailing text after the language id; allow 0–3 spaces of indent on the closing fence).

## Test plan
- [x] Open a markdown file with a ` ```jaw ` block followed by regular markdown — highlighting stops at the closing fence
- [x] Verify `.jaw` files still highlight correctly