### PR TITLE
Add install script for prebuilt releases

### DIFF
--- a/docs/installation/vscode.md
+++ b/docs/installation/vscode.md
@@ -1,6 +1,28 @@
 # VS Code Installation
 
-## Option A: Prebuilt download (recommended)
+## Option A: Install script (recommended, macOS / Linux)
+
+Clone the repo and run:
+
+```bash
+./scripts/install.sh
+```
+
+This downloads the latest release, installs `jaw-lsp` to `~/.local/bin/`
+(override with `JAW_INSTALL_DIR=...`), strips the macOS quarantine
+attribute, and installs the VS Code extension via the `code` CLI. Pass an
+explicit tag to pin a version: `./scripts/install.sh v0.1.1`.
+
+After installing, set `jaw.server.path` in VS Code settings to the absolute
+path of `jaw-lsp` (or skip this step if `~/.local/bin` is on your `PATH`):
+
+```json
+{
+  "jaw.server.path": "/absolute/path/to/jaw-lsp"
+}
+```
+
+## Option B: Prebuilt download (manual)
 
 1. Go to the [Releases page](https://github.com/dishmint/jaw/releases) and download:
    - The `.vsix` extension file (e.g. `jaw-language-0.1.0.vsix`)
@@ -28,7 +50,7 @@
 
    If `jaw-lsp` is on your `PATH`, this step is optional.
 
-## Option B: Build from source
+## Option C: Build from source
 
 ### Prerequisites
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Install (or update) JAW from the latest GitHub release.
+#
+# Downloads the jaw-lsp binary for the current platform and the VS Code
+# extension VSIX, installs jaw-lsp to ~/.local/bin, and installs the VSIX
+# via the `code` CLI.
+#
+# Usage:
+#   scripts/install.sh                # latest release
+#   scripts/install.sh v0.1.1         # specific tag
+#
+# Requirements: curl, tar, and (for the extension) the `code` CLI on PATH.
+
+set -euo pipefail
+
+REPO="dishmint/jaw"
+INSTALL_DIR="${JAW_INSTALL_DIR:-$HOME/.local/bin}"
+
+# --- detect platform ---------------------------------------------------------
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+
+case "$uname_s" in
+  Darwin)
+    case "$uname_m" in
+      arm64)  TARGET="aarch64-apple-darwin" ;;
+      x86_64) TARGET="x86_64-apple-darwin" ;;
+      *) echo "Unsupported macOS arch: $uname_m" >&2; exit 1 ;;
+    esac
+    ARCHIVE_EXT="tar.gz"
+    ;;
+  Linux)
+    case "$uname_m" in
+      x86_64) TARGET="x86_64-unknown-linux-gnu" ;;
+      *) echo "Unsupported Linux arch: $uname_m" >&2; exit 1 ;;
+    esac
+    ARCHIVE_EXT="tar.gz"
+    ;;
+  *)
+    echo "Unsupported OS: $uname_s (use the Windows release manually)" >&2
+    exit 1
+    ;;
+esac
+
+# --- resolve release tag -----------------------------------------------------
+TAG="${1:-}"
+if [[ -z "$TAG" ]]; then
+  echo "==> Fetching latest release tag"
+  TAG="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | grep -m1 '"tag_name"' \
+    | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+  if [[ -z "$TAG" ]]; then
+    echo "Failed to resolve latest release tag" >&2
+    exit 1
+  fi
+fi
+echo "==> Using release $TAG"
+
+BASE_URL="https://github.com/$REPO/releases/download/$TAG"
+LSP_ARCHIVE="jaw-lsp-$TARGET.$ARCHIVE_EXT"
+
+# --- download into a temp dir ------------------------------------------------
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "==> Downloading $LSP_ARCHIVE"
+curl -fsSL -o "$tmpdir/$LSP_ARCHIVE" "$BASE_URL/$LSP_ARCHIVE"
+
+echo "==> Extracting jaw-lsp"
+tar -xzf "$tmpdir/$LSP_ARCHIVE" -C "$tmpdir"
+
+mkdir -p "$INSTALL_DIR"
+install -m 0755 "$tmpdir/jaw-lsp" "$INSTALL_DIR/jaw-lsp"
+
+# Strip macOS quarantine attribute (release binaries are unsigned).
+if [[ "$uname_s" == "Darwin" ]]; then
+  xattr -d com.apple.quarantine "$INSTALL_DIR/jaw-lsp" 2>/dev/null || true
+fi
+
+echo "==> Installed jaw-lsp to $INSTALL_DIR/jaw-lsp"
+
+# --- install the VS Code extension -------------------------------------------
+# The VSIX file name is published as jaw-language-<version>.vsix where <version>
+# is the tag without the leading "v".
+VERSION="${TAG#v}"
+VSIX_FILE="jaw-language-$VERSION.vsix"
+
+echo "==> Downloading $VSIX_FILE"
+curl -fsSL -o "$tmpdir/$VSIX_FILE" "$BASE_URL/$VSIX_FILE"
+
+if command -v code >/dev/null 2>&1; then
+  echo "==> Installing VS Code extension"
+  code --install-extension "$tmpdir/$VSIX_FILE" --force
+else
+  echo "==> 'code' CLI not found; skipping VS Code extension install."
+  echo "    Install it manually from: $tmpdir/$VSIX_FILE"
+  echo "    (or re-run after enabling 'Shell Command: Install code command in PATH')"
+fi
+
+cat <<EOF
+
+Done. Make sure $INSTALL_DIR is on your PATH, then set in VS Code:
+
+  "jaw.server.path": "$INSTALL_DIR/jaw-lsp"
+
+Reload VS Code to pick up the new extension and LSP binary.
+EOF


### PR DESCRIPTION
## Summary
- New \`scripts/install.sh\` automates the prebuilt-release install flow: detects platform, fetches the latest release tag (or an explicit one), downloads + extracts \`jaw-lsp\` to \`~/.local/bin\`, strips the macOS quarantine attr, and installs the VSIX via the \`code\` CLI.
- Documents it as Option A in \`docs/installation/vscode.md\`; the previous manual flow is now Option B and source build is Option C.

## Test plan
- [x] Ran \`./scripts/install.sh\` on macOS x86_64 against v0.1.1 — \`jaw-lsp\` installed, quarantine cleared, \`code --list-extensions\` shows \`dishmint.jaw-language@0.1.1\`.
- [ ] Test explicit tag arg: \`./scripts/install.sh v0.1.0\`
- [ ] Test on Linux x86_64