### PR TITLE
Add -=, *=, /= compound operators to grammar

### DIFF
--- a/editors/vscode/syntaxes/jaw.tmLanguage.json
+++ b/editors/vscode/syntaxes/jaw.tmLanguage.json
@@ -265,7 +265,7 @@
       "name": "keyword.operator.iterator.jaw"
     },
     "operators": {
-      "match": "<<|==|!=|>=|<=|\\+=|[+\\-*/><]",
+      "match": "<<|==|!=|>=|<=|\\+=|-=|\\*=|/=|[+\\-*/><]",
       "name": "keyword.operator.jaw"
     }
   }


### PR DESCRIPTION
## Summary
- The operators alternation in `jaw.tmLanguage.json` only matched `+=` among compound assignments. `-=` was being split into `-` (matched as a single-char operator) followed by an unscoped `=`, which rendered as plain text.
- Added `-=`, `*=`, `/=` to the alternation, listed before the single-char class so they take precedence.

## Note
Compound assignment operators aren't currently documented in `jaw-grammar.md` or `docs/glossary.md`. The spec should probably catch up — happy to do that as a follow-up.

## Test plan
- [x] Verified `-=`, `+=`, `*=`, `/=` all highlight as single `keyword.operator.jaw` tokens
- [x] Bare `+`, `-`, `*`, `/`, `<`, `>`, `<<`, `==`, `!=`, `<=`, `>=` still highlight correctly