### PR TITLE
Parse top-level steps so the LSP can lint them

### DIFF
--- a/jaw-lsp/src/diagnostics.rs
+++ b/jaw-lsp/src/diagnostics.rs
@@ -129,12 +129,46 @@ pub fn check_bare_function_refs(ast: &Source, source: &str) -> Vec<LspDiagnostic
     let mut warnings = Vec::new();
 
     for item in &ast.items {
-        if let TopLevel::Function(f) = item {
-            check_block_for_bare_refs(&f.body, source, &func_names, &mut warnings);
+        match item {
+            TopLevel::Function(f) => {
+                check_block_for_bare_refs(&f.body, source, &func_names, &mut warnings);
+            }
+            TopLevel::Step(step) => {
+                check_step_for_bare_refs(step, source, &func_names, &mut warnings);
+            }
+            _ => {}
         }
     }
 
     warnings
+}
+
+fn check_step_for_bare_refs(
+    step: &Step,
+    source: &str,
+    func_names: &HashSet<String>,
+    warnings: &mut Vec<LspDiagnostic>,
+) {
+    match &step.expression {
+        Expression::Code(s) => {
+            check_text_for_bare_refs(source, s, step.span.start, func_names, warnings);
+        }
+        Expression::Conditional(c) => {
+            for branch in &c.branches {
+                check_text_for_bare_refs(
+                    source, &branch.condition, step.span.start, func_names, warnings,
+                );
+                check_text_for_bare_refs(
+                    source, &branch.consequence, step.span.start, func_names, warnings,
+                );
+            }
+            if let Some(ref else_text) = c.else_branch {
+                check_text_for_bare_refs(
+                    source, else_text, step.span.start, func_names, warnings,
+                );
+            }
+        }
+    }
 }
 
 fn check_block_for_bare_refs(

--- a/jaw-parse/src/ast.rs
+++ b/jaw-parse/src/ast.rs
@@ -12,6 +12,7 @@ pub enum TopLevel {
     Variable(Variable),
     Function(Function),
     Comment(Comment),
+    Step(Step),
     Text(TextNode),
 }
 

--- a/jaw-parse/src/parser.rs
+++ b/jaw-parse/src/parser.rs
@@ -60,9 +60,12 @@ impl Parser {
                         }
                     }
                     BracketContent::Number => {
-                        // Step at top level — unusual but valid
-                        self.skip_to_newline();
-                        None
+                        // Step at top level — unusual but valid.
+                        // Reuse the in-block step parser with block_indent = 0.
+                        match self.parse_step_or_complex_cond(0) {
+                            Some(BlockItem::Step(s)) => Some(TopLevel::Step(s)),
+                            _ => None,
+                        }
                     }
                     BracketContent::Caret => self.parse_comment().map(TopLevel::Comment),
                     BracketContent::Asterisk => self.parse_comment().map(TopLevel::Comment),


### PR DESCRIPTION
## Summary
- The parser was silently discarding any \`[N] — ...\` step that appeared outside a \`/function\` body (\`parse_top_level\` called \`skip_to_newline()\` and returned \`None\`). As a result the LSP couldn't see those steps, and the \"did you mean \`/add\`?\" warning never fired on bare function refs in top-level steps like \`samples/basic.jaw:21\`.
- Added a \`TopLevel::Step\` variant, parsed top-level steps via the existing \`parse_step_or_complex_cond\` (with \`block_indent = 0\`), and taught \`diagnostics::check_bare_function_refs\` to walk them.
- Top-level complex conditionals are still dropped (they were before too) — easy to add in a follow-up if needed.

## Test plan
- [x] \`cargo build --release\` clean
- [x] \`cargo test\` — all 18 tests pass
- [x] Installed the new \`jaw-lsp\` and reloaded VS Code; \`samples/basic.jaw\` line 21 (\`[1] — add[ [V], [M] ]\`) now shows the bare-function-ref warning