### PR TITLE
Scope LSP goto-def to enclosing function; add variable completion

### DIFF
--- a/jaw-lsp/src/completion.rs
+++ b/jaw-lsp/src/completion.rs
@@ -1,0 +1,182 @@
+use std::collections::HashSet;
+
+use jaw_parse::ast::*;
+use serde_json::{json, Value};
+
+/// LSP CompletionItemKind::Variable
+const KIND_VARIABLE: u32 = 6;
+
+/// Produce completion items at the given byte offset.
+///
+/// Only fires inside a `[ ... ]` bracket context — JAW variable references
+/// always live between brackets. Enclosing-function locals (args +
+/// inline-assigns) rank first; top-level variables fall back.
+pub fn completion_at(ast: &Source, source: &str, offset: usize) -> Value {
+    if !in_bracket_context(source, offset) {
+        return empty_list();
+    }
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut items: Vec<Value> = Vec::new();
+
+    if let Some(func) = find_enclosing_function(ast, offset) {
+        for arg in &func.args {
+            if seen.insert(arg.name.clone()) {
+                items.push(item(
+                    &arg.name,
+                    &format!("arg of /{}", func.name),
+                    &arg.description,
+                ));
+            }
+        }
+        collect_assigns(&func.body, &func.name, &mut seen, &mut items);
+    }
+
+    for top in &ast.items {
+        if let TopLevel::Variable(v) = top {
+            if seen.insert(v.name.clone()) {
+                items.push(item(&v.name, "global", &v.description));
+            }
+        }
+    }
+
+    json!({ "isIncomplete": false, "items": items })
+}
+
+fn item(name: &str, detail: &str, doc: &str) -> Value {
+    json!({
+        "label": name,
+        "kind": KIND_VARIABLE,
+        "detail": detail,
+        "documentation": doc,
+        "insertText": name,
+    })
+}
+
+fn collect_assigns(
+    block: &CodeBlock,
+    fn_name: &str,
+    seen: &mut HashSet<String>,
+    items: &mut Vec<Value>,
+) {
+    for b in &block.items {
+        match b {
+            BlockItem::InlineAssign(a) => {
+                if seen.insert(a.name.clone()) {
+                    items.push(item(
+                        &a.name,
+                        &format!("local in /{}", fn_name),
+                        &a.description,
+                    ));
+                }
+            }
+            BlockItem::Loop(lp) => collect_assigns(&lp.body, fn_name, seen, items),
+            BlockItem::Parallel(par) => collect_assigns(&par.body, fn_name, seen, items),
+            _ => {}
+        }
+    }
+}
+
+fn find_enclosing_function(ast: &Source, offset: usize) -> Option<&Function> {
+    for top in &ast.items {
+        if let TopLevel::Function(f) = top {
+            if offset >= f.span.start && offset < f.span.end {
+                return Some(f);
+            }
+        }
+    }
+    None
+}
+
+/// True if the cursor sits inside an unclosed `[` on the current line.
+fn in_bracket_context(source: &str, offset: usize) -> bool {
+    let bytes = source.as_bytes();
+    let mut i = offset;
+    while i > 0 {
+        let b = bytes[i - 1];
+        if b == b'[' {
+            return true;
+        }
+        if b == b']' || b == b'\n' {
+            return false;
+        }
+        i -= 1;
+    }
+    false
+}
+
+fn empty_list() -> Value {
+    json!({ "isIncomplete": false, "items": [] })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jaw_parse::parse;
+
+    fn labels(v: &Value) -> Vec<String> {
+        v["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|it| it["label"].as_str().unwrap().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn returns_nothing_outside_brackets() {
+        let source = "[V] — a vector\n\n/use\n\t[>] V\n";
+        let (ast, _) = parse(source);
+        // Offset at the bare `V` on line 3 — not inside brackets.
+        let offset = source.rfind("] V").unwrap() + 2;
+        let result = completion_at(&ast, source, offset);
+        assert!(result["items"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn offers_enclosing_function_args_and_globals() {
+        let source = "[V] — a vector\n[T] — a threshold\n\n/use [X]: a number\n\t[>] [\n";
+        let (ast, _) = parse(source);
+        // Offset immediately after the trailing `[` on the [>] line.
+        let offset = source.rfind('[').unwrap() + 1;
+        let result = completion_at(&ast, source, offset);
+        let names = labels(&result);
+        assert!(names.contains(&"X".to_string()), "missing arg X: {:?}", names);
+        assert!(names.contains(&"V".to_string()), "missing global V: {:?}", names);
+        assert!(names.contains(&"T".to_string()), "missing global T: {:?}", names);
+    }
+
+    #[test]
+    fn offers_inline_assigns_from_body() {
+        let source = "/process\n[V]: a list\n\t[R]: results\n\t[L]: length\n\t[1] — [\n";
+        let (ast, _) = parse(source);
+        let offset = source.rfind('[').unwrap() + 1;
+        let result = completion_at(&ast, source, offset);
+        let names = labels(&result);
+        assert!(names.contains(&"R".to_string()), "missing [R]: {:?}", names);
+        assert!(names.contains(&"L".to_string()), "missing [L]: {:?}", names);
+        assert!(names.contains(&"V".to_string()), "missing arg V: {:?}", names);
+    }
+
+    #[test]
+    fn does_not_leak_other_functions_locals() {
+        let source = "/a [X]: a number\n\t[1] — [Y]: local = [X]\n\n/b [Q]: other\n\t[1] — [\n";
+        let (ast, _) = parse(source);
+        let offset = source.rfind('[').unwrap() + 1;
+        let result = completion_at(&ast, source, offset);
+        let names = labels(&result);
+        assert!(names.contains(&"Q".to_string()), "expected Q from /b: {:?}", names);
+        assert!(!names.contains(&"X".to_string()), "X should not leak from /a: {:?}", names);
+    }
+
+    #[test]
+    fn partial_prefix_inside_brackets_triggers() {
+        // Common case: user is typing `[Us` and completion fires mid-word.
+        let source = "[User] — a user\n\n/show\n\t[>] [Us\n";
+        let (ast, _) = parse(source);
+        let offset = source.rfind("[Us").unwrap() + 3;
+        let result = completion_at(&ast, source, offset);
+        let names = labels(&result);
+        assert!(names.contains(&"User".to_string()), "missing User: {:?}", names);
+    }
+}

--- a/jaw-lsp/src/goto.rs
+++ b/jaw-lsp/src/goto.rs
@@ -3,38 +3,48 @@ use jaw_parse::token::Span;
 use serde_json::{json, Value};
 
 /// Find the definition of a variable referenced at the given byte offset.
+///
+/// Scoping rules: prefer the enclosing function's args and inline-assigns
+/// over top-level variables. Never resolve a reference to a same-named
+/// variable inside a *different* function.
 pub fn goto_definition(ast: &Source, source: &str, offset: usize) -> Option<Value> {
-    // First, figure out what identifier is at the offset
     let ident = find_identifier_at(source, offset)?;
 
-    // Search for the definition
+    if let Some(func) = find_enclosing_function(ast, offset) {
+        if let Some(loc) = find_in_function(func, &ident, source) {
+            return Some(loc);
+        }
+    }
+
     for item in &ast.items {
-        match item {
-            TopLevel::Variable(v) => {
-                if v.name == ident {
-                    return Some(location_response(&v.span, source));
-                }
+        if let TopLevel::Variable(v) = item {
+            if v.name == ident {
+                return Some(location_response(&v.span, source));
             }
-            TopLevel::Function(f) => {
-                if f.name == ident {
-                    return Some(location_response(&f.span, source));
-                }
-                // Check function args
-                for arg in &f.args {
-                    if arg.name == ident {
-                        return Some(location_response(&arg.span, source));
-                    }
-                }
-                // Check inline assigns in function body
-                if let Some(loc) = search_block_for_def(&f.body, &ident, source) {
-                    return Some(loc);
-                }
-            }
-            _ => {}
         }
     }
 
     None
+}
+
+fn find_enclosing_function(ast: &Source, offset: usize) -> Option<&Function> {
+    for item in &ast.items {
+        if let TopLevel::Function(f) = item {
+            if offset >= f.span.start && offset < f.span.end {
+                return Some(f);
+            }
+        }
+    }
+    None
+}
+
+fn find_in_function(f: &Function, ident: &str, source: &str) -> Option<Value> {
+    for arg in &f.args {
+        if arg.name == ident {
+            return Some(location_response(&arg.span, source));
+        }
+    }
+    search_block_for_def(&f.body, ident, source)
 }
 
 fn search_block_for_def(block: &CodeBlock, ident: &str, source: &str) -> Option<Value> {
@@ -119,4 +129,69 @@ fn location_response(span: &Span, source: &str) -> Value {
             "end": { "line": end_line, "character": end_char }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jaw_parse::parse;
+
+    #[test]
+    fn resolves_arg_within_same_function() {
+        let source = "/classify [X]: a number\n\t[>] [X]\n\n/handle [X]: a number\n\t[>] [X] * 2\n";
+        let (ast, _diags) = parse(source);
+
+        // `[X]` on the `[>]` line of /handle — second function.
+        let offset = source.find("[>] [X] * 2").unwrap() + 5;
+        let loc = goto_definition(&ast, source, offset).expect("definition found");
+
+        // It must point at /handle's [X], which is on line 3 (0-indexed), not /classify's line 0.
+        let line = loc["range"]["start"]["line"].as_u64().unwrap();
+        assert_eq!(line, 3, "expected /handle's [X] on line 3, got line {}", line);
+    }
+
+    #[test]
+    fn falls_back_to_top_level_variable() {
+        let source = "[V] — a vector\n[T] — a threshold\n\n/use [X]: a number\n\t[>] [V] + [X]\n";
+        let (ast, _diags) = parse(source);
+
+        // Click on `[V]` inside /use.
+        let offset = source.find("[>] [V]").unwrap() + 5;
+        let loc = goto_definition(&ast, source, offset).expect("definition found");
+
+        let line = loc["range"]["start"]["line"].as_u64().unwrap();
+        assert_eq!(line, 0, "expected top-level [V] on line 0, got line {}", line);
+    }
+
+    #[test]
+    fn does_not_leak_across_functions() {
+        // /a has [X] but /b does not — clicking [X] in /b must NOT resolve to /a.
+        let source = "/a [X]: a number\n\t[>] [X]\n\n/b\n[Y]: a thing\n\t[>] [X]\n";
+        let (ast, _diags) = parse(source);
+
+        let offset = source.rfind("[X]").unwrap() + 1;
+        let loc = goto_definition(&ast, source, offset);
+
+        assert!(
+            loc.is_none(),
+            "expected no definition (dangling ref), got {:?}",
+            loc
+        );
+    }
+
+    #[test]
+    fn resolves_inline_assign_inside_function_body() {
+        // An inline-assign declared as its own line in the function body, then
+        // referenced later in a step expression, should resolve back to the assign.
+        let source = "/process\n[V]: a list\n\t[R]: results\n\t[1] — [R]\n";
+        let (ast, _diags) = parse(source);
+
+        // Point at the `R` inside `[R]` on the step line.
+        let ref_offset = source.rfind("[R]").unwrap() + 1;
+        let loc = goto_definition(&ast, source, ref_offset).expect("definition found");
+        let line = loc["range"]["start"]["line"].as_u64().unwrap();
+        // [R]: results is on line 2 (0-indexed).
+        assert_eq!(line, 2);
+    }
+
 }

--- a/jaw-lsp/src/main.rs
+++ b/jaw-lsp/src/main.rs
@@ -1,3 +1,4 @@
+mod completion;
 mod diagnostics;
 mod goto;
 mod hover;

--- a/jaw-lsp/src/server.rs
+++ b/jaw-lsp/src/server.rs
@@ -3,6 +3,7 @@ use std::io::{BufRead, Write};
 
 use serde_json::{json, Value};
 
+use crate::completion::completion_at;
 use crate::diagnostics::publish_diagnostics_params;
 use crate::goto::goto_definition;
 use crate::hover::hover_at;
@@ -57,7 +58,10 @@ impl Server {
                     "capabilities": {
                         "textDocumentSync": 1,
                         "hoverProvider": true,
-                        "definitionProvider": true
+                        "definitionProvider": true,
+                        "completionProvider": {
+                            "triggerCharacters": ["["]
+                        }
                     },
                     "serverInfo": {
                         "name": "jaw-lsp",
@@ -117,6 +121,12 @@ impl Server {
 
             "textDocument/definition" => {
                 let result = self.handle_definition(&msg.params);
+                let resp = RpcResponse::success(msg.id, result.unwrap_or(Value::Null));
+                let _ = rpc::write_message(writer, &resp);
+            }
+
+            "textDocument/completion" => {
+                let result = self.handle_completion(&msg.params);
                 let resp = RpcResponse::success(msg.id, result.unwrap_or(Value::Null));
                 let _ = rpc::write_message(writer, &resp);
             }
@@ -185,6 +195,19 @@ impl Server {
             obj.insert("uri".to_string(), json!(uri));
         }
         Some(result)
+    }
+
+    fn handle_completion(&self, params: &Option<Value>) -> Option<Value> {
+        let params = params.as_ref()?;
+        let uri = params["textDocument"]["uri"].as_str()?;
+        let line = params["position"]["line"].as_u64()? as usize;
+        let character = params["position"]["character"].as_u64()? as usize;
+
+        let source = self.documents.get(uri)?;
+        let ast = self.asts.get(uri)?;
+        let offset = position_to_offset(source, line, character)?;
+
+        Some(completion_at(ast, source, offset))
     }
 }
 

--- a/samples/lsp-test/goto-scoping-44.jaw
+++ b/samples/lsp-test/goto-scoping-44.jaw
@@ -1,0 +1,8 @@
+[*] — Repro for #44: cmd+click [X] inside /handle should jump to /handle's [X]
+[*] — on line 5, NOT to /classify's [X] on line 1.
+
+/classify [X]: a number
+	[>] [X]
+
+/handle [X]: a number
+	[>] [X] * 2


### PR DESCRIPTION
## Summary

- Closes #44 — goto-definition now resolves variable refs against the enclosing function's args and inline-assigns first, falling back to top-level variables only when there's no enclosing function or no in-function match. Refs in one function will no longer leak to a same-named def in a sibling.
- Closes #45 — adds completion for variable references: triggers inside `[…]` and offers in-scope variables (function args, inline-assigns, top-level vars) for the position being edited.
- Includes a repro sample at `samples/lsp-test/goto-scoping-44.jaw` (two sibling functions both using `[X]`) for manual verification in the Extension Development Host.

## Test plan

- [x] `~/.cargo/bin/cargo test -p jaw-lsp goto` — 4/4 pass, including `does_not_leak_across_functions` and `resolves_arg_within_same_function`
- [x] `~/.cargo/bin/cargo test` — full suite passes
- [x] Manually verified in VS Code: cmd+click on `[X]` inside `/handle` in `samples/lsp-test/goto-scoping-44.jaw` lands on `/handle`'s `[X]` arg, not `/classify`'s
- [ ] Verify variable completion offers in-scope vars when typing inside `[…]`

## Notes for reviewers

While verifying this PR, I hit a stale-binary trap: `~/.local/bin/jaw-lsp` was an older release install, and `cargo build --release` doesn't update it. Filed #46 to track adding a `--from-source` mode to `scripts/install.sh` so this won't bite future contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)