### PR TITLE
install.sh: detect host arch via sysctl on macOS (#39)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,11 +23,14 @@ uname_m="$(uname -m)"
 
 case "$uname_s" in
   Darwin)
-    case "$uname_m" in
-      arm64)  TARGET="aarch64-apple-darwin" ;;
-      x86_64) TARGET="x86_64-apple-darwin" ;;
-      *) echo "Unsupported macOS arch: $uname_m" >&2; exit 1 ;;
-    esac
+    # `uname -m` reports the *process* arch, which inherits from the parent
+    # and reads as x86_64 under Rosetta even on Apple Silicon. Use sysctl to
+    # query the host arch directly.
+    if [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" == "1" ]]; then
+      TARGET="aarch64-apple-darwin"
+    else
+      TARGET="x86_64-apple-darwin"
+    fi
     ARCHIVE_EXT="tar.gz"
     ;;
   Linux)


### PR DESCRIPTION
## Summary

- Closes #39 — `scripts/install.sh` no longer mis-detects the host arch when invoked from a Rosetta'd shell on Apple Silicon. On Darwin we now query `sysctl -n hw.optional.arm64` (host arch) instead of relying on `uname -m` (process arch).
- Linux path is unchanged — still uses `uname -m`, which is correct there.

## Test plan

- [x] `bash -n scripts/install.sh` — syntax clean
- [x] Native arm64 shell on Apple Silicon → resolves `aarch64-apple-darwin`
- [x] `arch -x86_64 bash` shell on the same host (`uname -m` reports `x86_64`) → still resolves `aarch64-apple-darwin`
- [ ] Smoke test on an actual Intel Mac (don't have one handy — `sysctl -n hw.optional.arm64` returns `0` there, falls through to `x86_64-apple-darwin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)