### PR TITLE
Highlight function refs in log statements (#40)

### DIFF
--- a/editors/vscode/syntaxes/jaw.tmLanguage.json
+++ b/editors/vscode/syntaxes/jaw.tmLanguage.json
@@ -63,6 +63,7 @@
         "6": {
           "name": "string.unquoted.log.jaw",
           "patterns": [
+            { "include": "#function-reference" },
             { "include": "#variable-reference" },
             { "include": "#access-operator" },
             { "include": "#step-reference" }
@@ -73,6 +74,7 @@
       "contentName": "string.unquoted.log.jaw",
       "patterns": [
         { "include": "#decorator" },
+        { "include": "#function-reference" },
         { "include": "#variable-reference" },
         { "include": "#access-operator" },
         { "include": "#step-reference" }

--- a/samples/logs.jaw
+++ b/samples/logs.jaw
@@ -1,0 +1,26 @@
+[V] — a vector
+[X] — some value
+[T] — a threshold
+
+[!] — done processing
+[^] plain log
+
+[!] — current value: [X]
+[^] log with a variable ref
+
+[!] — calling /Process now
+[^] log with a function ref (regression cover for #40)
+
+[!] — see step [3] for context
+[^] log with a step ref
+
+[!] — #warn skipping [X] at threshold [T]
+[^] log with a decorator and variable refs
+
+[!] — FlagDetail:
+	[1] — caller: /Process
+	[2] — value: [X]
+[^] log title form, with continuation lines
+
+[!] — element [V]@[X] is out of range
+[^] log with an array-access expression


### PR DESCRIPTION
## Summary

- Closes #40 — function refs (e.g. `/Process`) inside `[!]` log statements now render as functions instead of plain text.
- Root cause: the `log` rule's content sub-patterns didn't include `#function-reference`. Other body contexts (`return`, `step`, `complex-cond-true/false`) already do, so this just brings `log` into line.
- Both edit sites are in the same rule: the `beginCaptures` content group (same-line content after `[!] —`) and the `patterns` array (continuation lines).

## Test plan

- [x] `python3 -c "import json; json.load(open('syntaxes/jaw.tmLanguage.json'))"` — JSON valid
- [ ] Visual: open Extension Development Host (F5 from `editors/vscode/`), type `[!] — calling /Process` in a `.jaw` file, confirm `/Process` highlights as a function
- [ ] Visual: confirm existing log highlighting still works (`#warn` decorator, `[X]` variable refs, `[3]` step refs, log-title form `[!] — TitleHere:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)