### PR TITLE
Add jaw-cli with `jaw export` subcommand (#42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jaw-cli"
+version = "0.1.3"
+
+[[package]]
 name = "jaw-lsp"
 version = "0.1.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["jaw-parse", "jaw-lsp"]
+members = ["jaw-parse", "jaw-lsp", "jaw-cli"]
 resolver = "2"

--- a/jaw-cli/Cargo.toml
+++ b/jaw-cli/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "jaw-cli"
+version = "0.1.3"
+edition = "2021"
+
+[[bin]]
+name = "jaw"
+path = "src/main.rs"

--- a/jaw-cli/src/export.rs
+++ b/jaw-cli/src/export.rs
@@ -1,0 +1,183 @@
+use crate::lang::{BlockComment, LangSpec};
+
+pub fn export(source: &str, lang: &LangSpec) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    let n = lines.len();
+    let mut out = String::with_capacity(source.len() * 2);
+    let mut i = 0;
+
+    while i < n {
+        let line = lines[i];
+        let trimmed = line.trim_start();
+
+        if (trimmed.starts_with("[*]") || trimmed.starts_with("[^]")) && lang.block.is_some() {
+            let end = continuation_end(&lines, i + 1);
+            if end > i + 1 {
+                emit_block(&mut out, &lines[i..end], lang.block.as_ref().unwrap());
+                i = end;
+                continue;
+            }
+        }
+
+        emit_line(&mut out, line, lang);
+        i += 1;
+    }
+
+    if source.ends_with('\n') && !out.ends_with('\n') {
+        out.push('\n');
+    }
+
+    out
+}
+
+fn continuation_end(lines: &[&str], from: usize) -> usize {
+    let mut end = from;
+    while end < lines.len() {
+        let l = lines[end];
+        if l.trim().is_empty() {
+            break;
+        }
+        if is_marker_line(l) {
+            break;
+        }
+        end += 1;
+    }
+    end
+}
+
+fn is_marker_line(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with('[')
+        || t.starts_with('/')
+        || t.starts_with("```")
+        || t.starts_with("~~~")
+}
+
+fn split_indent(line: &str) -> (&str, &str) {
+    let i = line.len() - line.trim_start().len();
+    line.split_at(i)
+}
+
+fn emit_line(out: &mut String, line: &str, lang: &LangSpec) {
+    if line.trim().is_empty() {
+        out.push('\n');
+        return;
+    }
+    let (indent, content) = split_indent(line);
+    out.push_str(indent);
+    out.push_str(lang.line_prefix);
+    out.push(' ');
+    out.push_str(content);
+    out.push('\n');
+}
+
+fn emit_block(out: &mut String, block_lines: &[&str], block: &BlockComment) {
+    let (indent, first_content) = split_indent(block_lines[0]);
+    out.push_str(indent);
+    out.push_str(block.open);
+    out.push(' ');
+    out.push_str(first_content);
+    out.push('\n');
+
+    let last_idx = block_lines.len() - 1;
+    for line in &block_lines[1..last_idx] {
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    out.push_str(block_lines[last_idx]);
+    out.push(' ');
+    out.push_str(block.close);
+    out.push('\n');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::lookup;
+
+    #[test]
+    fn python_per_line() {
+        let src = "[V] — a vector\n[!] — done\n";
+        let out = export(src, lookup("python").unwrap());
+        assert_eq!(out, "# [V] — a vector\n# [!] — done\n");
+    }
+
+    #[test]
+    fn rust_per_line() {
+        let src = "[V] — a vector\n";
+        let out = export(src, lookup("rust").unwrap());
+        assert_eq!(out, "// [V] — a vector\n");
+    }
+
+    #[test]
+    fn preserves_indentation() {
+        let src = "/foo\n\t[1] — step\n";
+        let out = export(src, lookup("python").unwrap());
+        assert_eq!(out, "# /foo\n\t# [1] — step\n");
+    }
+
+    #[test]
+    fn preserves_blank_lines() {
+        let src = "[V] — a\n\n[T] — b\n";
+        let out = export(src, lookup("python").unwrap());
+        assert_eq!(out, "# [V] — a\n\n# [T] — b\n");
+    }
+
+    #[test]
+    fn multiline_general_comment_becomes_block_in_c_style() {
+        let src = "[*] — first line\ncontinuation line\nlast line\n[1] — step\n";
+        let out = export(src, lookup("rust").unwrap());
+        assert_eq!(
+            out,
+            "/* [*] — first line\ncontinuation line\nlast line */\n// [1] — step\n"
+        );
+    }
+
+    #[test]
+    fn multiline_general_comment_stays_per_line_in_hash_lang() {
+        let src = "[*] — first line\ncontinuation line\n[1] — step\n";
+        let out = export(src, lookup("python").unwrap());
+        assert_eq!(
+            out,
+            "# [*] — first line\n# continuation line\n# [1] — step\n"
+        );
+    }
+
+    #[test]
+    fn single_line_general_comment_stays_per_line() {
+        let src = "[*] — just one line\n[1] — step\n";
+        let out = export(src, lookup("rust").unwrap());
+        assert_eq!(out, "// [*] — just one line\n// [1] — step\n");
+    }
+
+    #[test]
+    fn blank_line_terminates_multiline_block() {
+        let src = "[*] — opens\ncontinues\n\n[1] — step\n";
+        let out = export(src, lookup("rust").unwrap());
+        assert_eq!(out, "/* [*] — opens\ncontinues */\n\n// [1] — step\n");
+    }
+
+    #[test]
+    fn code_comment_marker_also_blocks() {
+        let src = "[^] explanation\nspans two lines\n[1] — step\n";
+        let out = export(src, lookup("rust").unwrap());
+        assert_eq!(
+            out,
+            "/* [^] explanation\nspans two lines */\n// [1] — step\n"
+        );
+    }
+
+    #[test]
+    fn unknown_lang_returns_none() {
+        assert!(lookup("klingon").is_none());
+    }
+
+    #[test]
+    fn lang_aliases_work() {
+        assert!(lookup("py").is_some());
+        assert!(lookup("rb").is_some());
+        assert!(lookup("ts").is_some());
+        assert!(lookup("PYTHON").is_some());
+    }
+}

--- a/jaw-cli/src/lang.rs
+++ b/jaw-cli/src/lang.rs
@@ -1,0 +1,71 @@
+pub struct LangSpec {
+    pub line_prefix: &'static str,
+    pub block: Option<BlockComment>,
+}
+
+pub struct BlockComment {
+    pub open: &'static str,
+    pub close: &'static str,
+}
+
+pub fn lookup(name: &str) -> Option<&'static LangSpec> {
+    LANGS
+        .iter()
+        .find(|(aliases, _)| aliases.iter().any(|a| a.eq_ignore_ascii_case(name)))
+        .map(|(_, spec)| spec)
+}
+
+pub fn known_languages() -> Vec<&'static str> {
+    LANGS.iter().map(|(aliases, _)| aliases[0]).collect()
+}
+
+const C_STYLE: LangSpec = LangSpec {
+    line_prefix: "//",
+    block: Some(BlockComment {
+        open: "/*",
+        close: "*/",
+    }),
+};
+
+const HASH_STYLE: LangSpec = LangSpec {
+    line_prefix: "#",
+    block: None,
+};
+
+const LANGS: &[(&[&str], LangSpec)] = &[
+    (&["python", "py"], HASH_STYLE),
+    (&["ruby", "rb"], HASH_STYLE),
+    (&["bash", "sh", "shell"], HASH_STYLE),
+    (
+        &["rust", "rs"],
+        LangSpec {
+            line_prefix: "//",
+            block: Some(BlockComment {
+                open: "/*",
+                close: "*/",
+            }),
+        },
+    ),
+    (&["javascript", "js"], C_STYLE),
+    (&["typescript", "ts"], C_STYLE),
+    (&["go"], C_STYLE),
+    (&["c"], C_STYLE),
+    (&["cpp", "c++", "cxx"], C_STYLE),
+    (
+        &["lua"],
+        LangSpec {
+            line_prefix: "--",
+            block: Some(BlockComment {
+                open: "--[[",
+                close: "]]",
+            }),
+        },
+    ),
+    (
+        &["sql"],
+        LangSpec {
+            line_prefix: "--",
+            block: None,
+        },
+    ),
+];

--- a/jaw-cli/src/main.rs
+++ b/jaw-cli/src/main.rs
@@ -1,0 +1,136 @@
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+mod export;
+mod lang;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match run(args) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(msg) => {
+            eprintln!("{}", msg);
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(args: Vec<String>) -> Result<(), String> {
+    let mut iter = args.into_iter();
+    let sub = iter.next();
+    match sub.as_deref() {
+        Some("export") => cmd_export(iter.collect()),
+        Some("--version") | Some("-V") => {
+            println!("{}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+        Some("--help") | Some("-h") | Some("help") | None => {
+            print_usage();
+            Ok(())
+        }
+        Some(other) => Err(format!(
+            "unknown subcommand: {}\n\n{}",
+            other,
+            usage_text()
+        )),
+    }
+}
+
+fn cmd_export(args: Vec<String>) -> Result<(), String> {
+    let mut lang_name: Option<String> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut input: Option<PathBuf> = None;
+    let mut iter = args.into_iter();
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--lang" | "-l" => {
+                lang_name = Some(
+                    iter.next()
+                        .ok_or_else(|| "--lang requires a value".to_string())?,
+                );
+            }
+            "--output" | "-o" => {
+                output = Some(PathBuf::from(
+                    iter.next()
+                        .ok_or_else(|| "--output requires a value".to_string())?,
+                ));
+            }
+            "--help" | "-h" => {
+                print_export_usage();
+                return Ok(());
+            }
+            s if s.starts_with('-') => {
+                return Err(format!("unknown flag for export: {}", s));
+            }
+            _ => {
+                if input.is_some() {
+                    return Err("export takes a single input file".to_string());
+                }
+                input = Some(PathBuf::from(arg));
+            }
+        }
+    }
+
+    let lang_name = lang_name.ok_or_else(|| {
+        format!(
+            "--lang is required (one of: {})",
+            lang::known_languages().join(", ")
+        )
+    })?;
+    let lang = lang::lookup(&lang_name).ok_or_else(|| {
+        format!(
+            "unknown language: {}\nsupported: {}",
+            lang_name,
+            lang::known_languages().join(", ")
+        )
+    })?;
+    let input = input.ok_or_else(|| "missing input file".to_string())?;
+
+    let source = fs::read_to_string(&input)
+        .map_err(|e| format!("could not read {}: {}", input.display(), e))?;
+    let result = export::export(&source, lang);
+
+    match output {
+        Some(path) => fs::write(&path, result)
+            .map_err(|e| format!("could not write {}: {}", path.display(), e))?,
+        None => {
+            let stdout = io::stdout();
+            let mut h = stdout.lock();
+            h.write_all(result.as_bytes())
+                .map_err(|e| format!("write to stdout failed: {}", e))?;
+        }
+    }
+    Ok(())
+}
+
+fn print_usage() {
+    println!("{}", usage_text());
+}
+
+fn usage_text() -> String {
+    format!(
+        "jaw {}\n\n\
+         USAGE:\n    \
+         jaw <SUBCOMMAND>\n\n\
+         SUBCOMMANDS:\n    \
+         export    Export a .jaw file as comments in a target language\n    \
+         help      Print this help\n",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
+fn print_export_usage() {
+    println!(
+        "jaw export — convert a .jaw file to target-language comments\n\n\
+         USAGE:\n    \
+         jaw export --lang LANG [--output PATH] FILE\n\n\
+         OPTIONS:\n    \
+         -l, --lang LANG       target language ({})\n    \
+         -o, --output PATH     write to PATH (default: stdout)\n    \
+         -h, --help            print this help\n",
+        lang::known_languages().join(", ")
+    );
+}


### PR DESCRIPTION
## Summary

- Closes #42 — new `jaw-cli` workspace crate ships a `jaw` binary. First subcommand: `jaw export --lang LANG [--output PATH] FILE`.
- V1 is comment-only export. Transpilation is intentionally deferred to a follow-up issue.
- Languages supported: python, ruby, bash, rust, javascript, typescript, go, c, cpp, lua, sql (with common aliases — `py`, `rb`, `js`, `ts`, `c++`, `cxx`, `sh`).

## Per-construct rule

Code-like jaw lines (steps, function defs, loops, returns, variable decls, inline-assigns) → one single-line comment per line, preserving indentation. The user can then swap each comment for a real implementation line without touching neighbors — that's the ergonomic promise of comment-export.

Multi-line `[*]` and `[^]` comment constructs collapse into one block comment **when the target language supports block comments** (rust, c, cpp, js, ts, go, lua). On hash-only languages (python, ruby, bash) and dash-only (sql) they stay per-line.

A blank line terminates a multi-line construct in the export tool — more conservative than the jaw parser, but more intuitive when reading exported output.

## Examples

`jaw export --lang python samples/basic.jaw`:
```
# [V] — a 1D vector
# /add [A]: an integer, [B]: an integer
	# [>] [A] + [B]
# [*] this is a general comment
# that spans multiple lines
# and keeps going
```

`jaw export --lang rust samples/basic.jaw` (note the block comment):
```
// [V] — a 1D vector
// /add [A]: an integer, [B]: an integer
	// [>] [A] + [B]
/* [*] this is a general comment
that spans multiple lines
and keeps going */
```

## Test plan

- [x] `cargo build -p jaw-cli` clean
- [x] `cargo test -p jaw-cli` — 11 tests pass (per-line, indentation preservation, blank-line handling, multi-line block emission for c-style, hash-style fallback, alias lookup)
- [x] `cargo test` — full workspace suite green
- [x] Smoke test on `samples/basic.jaw` for python, rust
- [x] Error paths: missing `--lang`, unknown language, missing input file
- [x] `--output PATH` writes to file; absent → stdout

## Out of scope (filed separately or noted in commit)

- Transpilation (`[!]` → `print(...)`, `[>]` → `return`, etc.)
- VS Code extension command wrapping the CLI
- `install.sh` shipping the new `jaw` binary (waits on a release tag including it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)