### PR TITLE
Add Claude Code skills for JAW (author, translate, review, and-implement)

### DIFF
--- a/.claude/skills/jaw-and-implement/SKILL.md
+++ b/.claude/skills/jaw-and-implement/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: jaw-and-implement
+description: Use when the user wants BOTH JAW pseudocode AND a working implementation together — e.g. "write JAW and Python for X", "spec plus code", "pseudocode and implement it in Rust". Output is a single source file with JAW lines as comments above the real code (mirrors `jaw export` shape). For JAW alone, use `jaw-author`. For converting an existing `.jaw` file to code, use `jaw-translate`.
+allowed-tools: Read, Write, Edit, Glob, Grep
+---
+
+# JAW + implementation in one file
+
+JAW is a **companion** to code, not a precursor. The output is a single file in the target language where JAW lines appear as comments above the code they describe. This mirrors what `jaw-cli export` produces — except here you write both the JAW and the code in one pass, so they stay in sync.
+
+**Do not** emit two separate fenced blocks (JAW first, code second). They belong adjacent.
+
+## Step 1 — confirm the target language
+
+If the user didn't specify, ask. Supported comment styles (matching `jaw-cli`'s language table — see `jaw-cli/src/lang.rs`):
+
+| Language | Line comment | Block comment |
+|----------|--------------|---------------|
+| Python, Ruby, Bash | `#` | (none — use per-line) |
+| Rust, JS, TS, Go, C, C++ | `//` | `/* */` (for multi-line `[*]`/`[^]`) |
+| Lua | `--` | `--[[ ]]` |
+| SQL | `--` | (none) |
+
+## Step 2 — design the JAW
+
+Before writing anything, draft the JAW algorithm mentally. Follow the rules from `.claude/skills/jaw-author/SKILL.md`:
+
+- Em dash `—` (U+2014), `/Title` for function refs, `[V]` for variable refs, `#name` for decorators.
+- Pick the right markers: `[N] —` step, `[~] —` loop, `[+]`/`[-]` complex conditional branches, `[!] —` log, `[>]` return, `[V] —` top-level variable, `[V]:` inline assign.
+- Function names are title case (`/BinarySearch`, not `/binary_search`).
+- **Conditionals with `?` require function calls**, per the grammar: `CODE ? FUNCTION_CALL | FUNCTION_CALL`. Don't write `[X] ? returnY | doZ` — either use real function refs (`? /Found | /Continue`) and define them, or describe the conditional in plain step text (`return [Y] if [X]`), or use the complex `[+]`/`[-]` form.
+
+If the JAW is non-trivial, read `docs/examples/example-func.jaw` to calibrate.
+
+## Step 3 — map JAW to code idioms
+
+Same as `.claude/skills/jaw-translate/SKILL.md` Mode 1:
+
+- `[~] — [X] in [Coll]` → for-each loop
+- `[~] — condition` → while loop
+- `[+] —` / `[-] —` complex conditional → if/else
+- `[N] — [A] > [B] ? /DoX | /DoY` chained conditional → if/else **dispatching to the named functions**
+- `[!] —` → log/print
+- `[>] expr` → return
+- `[R] << x` → append `x` to collection
+- `[V]@[P]` → indexed access
+- Inline assigns with `= value` → parameter defaults
+
+## Step 4 — emit a single fenced block
+
+Wrap the output in one fenced code block for the target language. Place JAW lines as comments **above** the code they describe.
+
+### Format conventions
+
+- **Top-level variable declarations** (`[V] — description`) → comment above the function signature, or above the relevant initialization.
+- **Function header** (`/Name [A]: ..., [B]: ...`) → comment above the function definition.
+- **Steps** (`[N] — ...`) → comment above the line(s) implementing that step. If a step is one line of code, the comment goes directly above. If it's several, the comment goes above the first.
+- **Inline assigns** (`[X]: desc = val`) → comment above the corresponding variable assignment.
+- **Loops, conditionals** (`[~] —`, `[+]`, `[-]`) → comment above the `while`/`for`/`if`/`else` line.
+- **Logs and returns** (`[!] —`, `[>]`) → comment above the print/return line.
+- **`[^]` code comments** and **`[*]` general comments** → keep as-is in comment form; multi-line ones can use block comment syntax in C-style languages.
+
+### Example shape (Python target)
+
+```python
+# /BinarySearch [V]: sorted list, [T]: target
+def binary_search(v, t):
+    # [L]: low = 0
+    # [H]: high = len([V]) - 1
+    low, high = 0, len(v) - 1
+
+    # [~] — [L] <= [H]
+    while low <= high:
+        # [1] — [M]: midpoint
+        mid = (low + high) // 2
+
+        # [2] — return [M] if [V]@[M] == [T]
+        if v[mid] == t:
+            return mid
+
+        # [3] — narrow [L]..[H] toward [T]
+        if v[mid] < t:
+            low = mid + 1
+        else:
+            high = mid - 1
+
+    # [>] -1
+    return -1
+```
+
+Note: steps `[2]` and `[3]` use plain step text rather than the `?` chained-conditional form, because the branches are inline operations (return, assignment) — not function calls. Using `?` would require defining `/Found`, `/SearchRight`, `/SearchLeft` and dispatching to them.
+
+### Example shape (Rust target — block comment for multi-line)
+
+```rust
+// /BinarySearch [V]: sorted slice, [T]: target
+fn binary_search(v: &[i32], t: i32) -> Option<usize> {
+    // [L]: low = 0, [H]: high = len([V]) - 1
+    let (mut low, mut high) = (0_isize, v.len() as isize - 1);
+
+    // [~] — [L] <= [H]
+    while low <= high {
+        // [1] — [M]: midpoint
+        let mid = ((low + high) / 2) as usize;
+
+        // [2] — return [M] if [V]@[M] == [T]
+        if v[mid] == t {
+            return Some(mid);
+        }
+
+        // [3] — narrow [L]..[H] toward [T]
+        if v[mid] < t {
+            low = mid as isize + 1;
+        } else {
+            high = mid as isize - 1;
+        }
+    }
+
+    // [>] None
+    None
+}
+```
+
+## Step 5 — self-check before returning
+
+1. **JAW rules:** em dashes U+2014, slashed function refs, title-case names, bracketed variables.
+2. **Grammar:** any `?` chained conditional dispatches to actual function calls (which exist or are clearly external) — no dangling `/Foo` refs.
+3. **Code correctness:** the code actually compiles/runs (mentally trace the golden path).
+4. **Sync:** every JAW step has a matching code section; every meaningful code section has a JAW comment above it. No orphans on either side.
+5. **Comment syntax:** matches the target language. Use block comments (`/* */`) for multi-line continuations in C-style languages.
+
+## Multiple target languages
+
+If the user asks for the same algorithm in multiple languages, emit one fenced block per language, each with its own interleaved JAW comments. Keep the JAW content identical across blocks (only the comment syntax changes).
+
+## When to suggest `jaw-cli export` instead
+
+If the user already has a `.jaw` file and just wants it converted to a code skeleton (comments only, no implementation), point them at `jaw-cli`:
+
+```bash
+~/.cargo/bin/cargo run -p jaw-cli -- export --lang <LANG> <FILE.jaw>
+```
+
+That's deterministic and handles all the comment-syntax mapping. This skill is for the case where they want *both* the comments AND a real implementation generated together.

--- a/.claude/skills/jaw-author/SKILL.md
+++ b/.claude/skills/jaw-author/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: jaw-author
+description: Use when the user wants to write JAW (Just A Word) pseudocode from a description, convert an algorithm or function into JAW, or asks what a JAW marker means. Triggers on `.jaw` files, "write JAW for X", "explain `[~]`", "what does this decorator do". For converting JAW into a real programming language, use `jaw-translate` instead. For linting an existing `.jaw` file, use `jaw-review`.
+allowed-tools: Read, Write, Edit, Glob, Grep
+---
+
+# Authoring JAW pseudocode
+
+JAW is a pseudocode/commenting language. Conventions are precise — if you guess from training data you will get details wrong. **Always load the spec before writing.**
+
+## Step 1 — load the spec
+
+Read these three files before producing JAW:
+
+- `jaw-grammar.md` — formal EBNF-style grammar (~60 lines)
+- `docs/glossary.md` — marker and term reference
+- `CLAUDE.md` — project conventions
+
+If the user only asked a definitional question ("what does `[~]` mean"), `docs/glossary.md` is enough.
+
+## Step 2 — apply the critical rules
+
+These rules are easy to get wrong and the parser/LSP will not all flag them:
+
+| Rule | Right | Wrong |
+|------|-------|-------|
+| Em dash separator | `—` (U+2014) | `-`, `--`, `–` |
+| Function refs | `/Add`, `/Process` | `Add`, `add` |
+| Function names | Title case `/HandlePositive` | `/handle_positive`, `/handlePositive` |
+| Variable refs | `[V]`, `[Result]` | `V`, `<V>` |
+| Decorators | `#mutable`, `#type:list` | `@mutable`, `mutable:` |
+| Array access | `[V]@[P]` | `[V][P]`, `[V].P` |
+
+## Step 3 — pick the right marker
+
+| Marker | When |
+|--------|------|
+| `[N] —` | A numbered algorithm step inside a function/loop/parallel block |
+| `[~] —` | Loop. Body is an indented block. Iteration form: `[A] in [Coll]` or `([A], [B]) in [Pairs]` |
+| `[&]` | Parallel block. Body is indented. |
+| `[+] —` / `[-] —` | True/false branches of a complex (multi-step) conditional |
+| `[!] —` | Log / print |
+| `[>]` | Return |
+| `[^]` | Code comment tied to the preceding step |
+| `[*]` | Standalone general comment |
+| `[V] —` | Variable declaration (at top level) |
+| `[V]:` | Inline assignment (inside a code block); optional `= value` |
+
+Conditionals come in two shapes:
+- **Chained on one line:** `[1] — [A] > [B] ? /DoX | [A] == [B] ? /DoY | /DoZ`
+- **Complex with multi-step branches:**
+  ```
+  [1] — [A] > [B] ?
+      [+] — /DoX
+      [-] — /DoY
+  ```
+
+## Step 4 — reference real examples
+
+When in doubt, read the matching example file rather than improvising:
+
+| Topic | File |
+|-------|------|
+| Function declarations | `docs/examples/functions.jaw` |
+| Variables and inline assignments | `docs/examples/variables.jaw` |
+| Conditionals (chained + complex) | `docs/examples/conditionals.jaw` |
+| Loops and destructured iteration | `docs/examples/loops.jaw` |
+| Decorators | `docs/examples/decorators.jaw` |
+| Logging | `docs/examples/logging.jaw` |
+| Returns | `docs/examples/returns.jaw` |
+| End-to-end algorithm (Zip + sum) | `docs/examples/example-func.jaw` |
+| Larger reference | `samples/full.jaw` |
+
+## Step 5 — self-check before returning
+
+Scan your output for these failure modes:
+
+1. **Em dashes:** every `[X] —` and `[N] —` uses U+2014, not `-` or `--`.
+2. **Function name case:** every `/Name` is title case.
+3. **Function refs are slashed:** function names appearing in step text (e.g. inside `[N] — result = Foo[...]`) must be `/Foo`, not bare `Foo`. The LSP will warn about this; you should not produce it.
+4. **Variables in brackets:** every variable reference uses `[V]`, not bare `V`.
+5. **Indentation:** code blocks inside functions/loops are indented one level.
+
+## Output conventions
+
+- For a single function or snippet, return JAW in a fenced block:
+  ```jaw
+  /MyFunc
+  [V]: input
+      [1] — ...
+      [>] [V]
+  ```
+- For multi-file work, write to `.jaw` files with the Write tool.
+- Don't surround JAW with explanatory prose unless the user asked for an explanation — JAW *is* the explanation.

--- a/.claude/skills/jaw-review/SKILL.md
+++ b/.claude/skills/jaw-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: jaw-review
+description: Use when the user wants to lint or review a `.jaw` file for semantic issues the parser/LSP doesn't catch — undefined function calls, unused variables, style violations (em dashes, title case, bare function refs), decorator hygiene. Triggers on "review this .jaw", "lint my JAW", "check this JAW file before commit". For writing JAW, use `jaw-author`. For translating JAW, use `jaw-translate`.
+allowed-tools: Read, Grep, Glob, Bash
+---
+
+# Reviewing a JAW file
+
+The parser (`jaw-parse`) and LSP (`jaw-lsp`) already catch syntax errors and one warning ("did you mean `/func`?" for bare names matching a known function). **Do not duplicate that work.** This skill covers the semantic and style gaps.
+
+## Step 1 — note the parser/LSP boundary
+
+There is currently **no CLI frontend** for the parser. `jaw-cli`'s `export` subcommand iterates lines text-only and does not run `jaw-parse`. The only ways to get syntax diagnostics today are:
+
+- Open the file in VS Code with the JAW extension installed (the LSP reports parse errors).
+- Add a `jaw check` subcommand to `jaw-cli` (out of scope for this skill).
+
+So: do not promise to run the parser. Mention to the user that for full syntax validation they should open the file in VS Code with the extension. Then proceed with the semantic and style checks below — these work on the raw file text and don't require a parsed AST.
+
+## Step 2 — load the file and the spec
+
+- Read the `.jaw` file fully.
+- Read `jaw-grammar.md` and `docs/glossary.md` to ground the checks below.
+
+## Step 3 — run the semantic checks
+
+Report findings grouped by severity. For each, output `<file>:<line>: <message>`, matching the LSP source format (`jaw` as the source name).
+
+### Errors
+
+1. **Undefined function calls.** Any `/Foo[ ... ]` call where no `/Foo` definition exists in this file. (The LSP warns on the *inverse* — bare `Foo` matching a known def — but does not flag calls to undefined functions.)
+   - Use Grep to find function definitions: `^/[A-Z]` patterns.
+   - Use Grep to find function calls: `/[A-Z][A-Za-z0-9_]*\[` patterns.
+   - Diff the call set against the definition set. Flag unmatched calls.
+   - Exception: if the user indicates external functions are expected, mention but don't error.
+
+### Warnings
+
+2. **Unused variables.** A top-level `[X] — description` declared but never referenced in any step, conditional, loop, or function body. Inline assigns (`[X]: ...`) inside function bodies are scoped — only flag truly unreferenced top-level declarations.
+
+3. **Bare function references in text.** A function name (matches a `/Foo` definition) appearing without the `/` prefix. The LSP already covers this — only mention it if the parser run in Step 1 surfaced such warnings.
+
+### Style
+
+4. **Em dash hygiene.** Every marker separator must be U+2014 `—`, not `-` or `--` or `–` (en dash). Grep for marker lines that use the wrong character: lines matching `^\s*\[[^\]]+\]\s*-+\s` (hyphen instead of em dash) or `^\s*/[A-Za-z][A-Za-z0-9_]*\s` followed by hyphen separators in args.
+
+5. **Function name case.** Every `/<name>` must start with an uppercase letter and use title case. Flag `/lowercase`, `/snake_case`, `/camelCase`.
+
+6. **Variable references in brackets.** Inside step text, names that look like declared variables but appear bare (e.g. `[1] — sort V` when `[V]` is declared). Lower confidence — only flag obvious cases where the bare name exactly matches a declared variable identifier.
+
+### Decorator hygiene
+
+7. **Unknown decorators.** Compile the set of decorators in use (`#name` or `#name:value`). Common decorators from `docs/examples/decorators.jaw` and the glossary: `#mutable`, `#pure`, `#error`, `#type`, `#complexity`. If the project has its own conventions doc, prefer that. Flag decorators that look like typos of known ones (e.g. `#mutabl`, `#pur`); do not flag unknown-but-plausible ones (the spec doesn't restrict the set).
+
+## Step 4 — produce the report
+
+Output format:
+
+```
+jaw-review: <file>
+
+Errors (N):
+  <file>:<line>: Undefined function call /Foo — no /Foo defined in this file
+  ...
+
+Warnings (N):
+  <file>:<line>: Unused variable [X]
+  ...
+
+Style (N):
+  <file>:<line>: Hyphen used instead of em dash —
+  <file>:<line>: Function name /handle_pos should be title case (/HandlePos)
+  ...
+
+Decorators (N):
+  <file>:<line>: Unknown decorator #mutabl — did you mean #mutable?
+  ...
+
+Clean checks: <list of categories that passed>
+```
+
+If everything is clean, say so explicitly and list which categories were checked. Don't invent issues to pad the output.
+
+## What not to do
+
+- Don't claim the parser was run when there's no CLI to invoke it. Be honest about the boundary (Step 1).
+- Don't flag missing definitions for functions the user has indicated are external (e.g. stdlib-equivalent calls).
+- Don't flag style issues in lines that are inside `[*]` or `[^]` comment continuations — those are free text.
+- Don't auto-fix unless the user asks. Report first, fix on request.

--- a/.claude/skills/jaw-translate/SKILL.md
+++ b/.claude/skills/jaw-translate/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: jaw-translate
+description: Use when the user wants to convert between JAW pseudocode and real source code. Three modes — (1) implement a `.jaw` file as runnable code in Python/Rust/TS/etc., (2) embed a `.jaw` file as comments inside a source file in any supported language, (3) summarize an existing function as JAW pseudocode. Triggers on "implement this JAW in <lang>", "translate this to JAW", "embed this as comments". For writing JAW from scratch, use `jaw-author`. For linting JAW, use `jaw-review`.
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Translating between JAW and real code
+
+Pick the mode based on what the user asked for. The three modes use different tools.
+
+## Mode 1 — JAW → runnable code (LLM task)
+
+The user wants a working implementation in a target language, not comments.
+
+1. Read the `.jaw` file with the Read tool.
+2. Infer types and semantics:
+   - Variable descriptions (`[V] — a 1D vector`) hint at types.
+   - Decorators carry intent: `#mutable` (assignable), `#pure` (no side effects), `#type:list`, `#error`, `#complexity:O(n)`.
+   - Inline assigns with defaults (`[N]: count = 0`) become parameter defaults.
+   - Function args `[A]: an integer, [B]: an integer` map to typed parameters.
+3. Translate construct by construct. Map JAW shapes to language idioms — not literal one-to-one. Examples:
+   - `[~] — [X] in [Coll]` → `for x in coll:` (or the language equivalent)
+   - `[~] — ([A], [B]) in [Pairs]` → destructured for-each
+   - `[+] — ... / [-] — ...` → if / else
+   - `[!] — message` → log/print (use the project's logger if visible in context)
+   - `[>] expr` → return
+   - `[N] — [R] << x` → append `x` to `[R]` (collection mutation)
+4. **Reference worked example:** `docs/examples/example-func.jaw` is a Zip + sum algorithm. Use it to calibrate how decorators and inline assigns translate.
+5. If the JAW references `/Foo` but no `/Foo` is defined in the file, ask the user whether `Foo` is an external function or whether they want it stubbed.
+
+## Mode 2 — JAW → comments in a source file (deterministic)
+
+The user wants their JAW embedded as comments — they're not asking for a real implementation, just a commented scaffold.
+
+Use the `jaw-cli` binary. **Do not reimplement comment formatting** — the CLI handles per-language syntax, multi-line block comments (`/* ... */` for C-style languages), and indentation preservation.
+
+```bash
+~/.cargo/bin/cargo run -p jaw-cli -- export --lang <LANG> <INPUT.jaw> --output <OUTPUT>
+```
+
+Supported languages (with aliases): `python`/`py`, `ruby`/`rb`, `bash`/`sh`, `rust`/`rs`, `javascript`/`js`, `typescript`/`ts`, `go`, `c`, `cpp`/`c++`, `lua`, `sql`. Source: `jaw-cli/src/lang.rs`.
+
+If the user wants the result printed to stdout, omit `--output`.
+
+If `jaw-cli` is not built, build first: `~/.cargo/bin/cargo build -p jaw-cli`.
+
+## Mode 3 — code → JAW pseudocode (LLM task)
+
+The user wants an existing function summarized as JAW comments/pseudocode.
+
+1. Read the source file and identify the function to translate.
+2. Load the JAW conventions first — read `jaw-grammar.md` and `docs/glossary.md`. **Critical rules** (or the LSP will warn / output will be invalid):
+   - Em dash `—` is U+2014, not `-` or `--`.
+   - Function references use `/Name` with title case (`/HandlePositive`).
+   - Variable references are bracket-enclosed: `[V]`, `[Result]`.
+   - Decorators use `#name` or `#name:value`.
+   - Array access is `[V]@[P]`, not `[V][P]`.
+3. Produce JAW. Map back from idioms:
+   - `for x in coll:` → `[~] — [X] in [Coll]`
+   - if/else with multi-line branches → `[+] —` / `[-] —`
+   - return → `[>]`
+   - print/log → `[!] —`
+   - typed parameters → inline assigns: `/Func [A]: an integer, [B]: a list`
+4. Pick the right granularity. Each numbered `[N] —` step should correspond to one meaningful action, not every line of code. JAW is for the algorithm, not a literal transliteration.
+5. Self-check using the same checklist as `jaw-author` — em dashes, slashed function refs, title-case names, bracketed variables.
+
+## Picking between modes
+
+If the user's request is ambiguous, ask. Mode 1 ("runnable code") and Mode 2 ("comments in a source file") look similar but produce very different output — get this right before generating.


### PR DESCRIPTION
## Summary

- Adds four repo-local Claude Code skills under `.claude/skills/` so contributors and end users get accurate help with JAW conventions (em dash U+2014, `/Title` function refs, bracket markers) instead of relying on the model's guesses.
- `jaw-author` writes JAW from a description; `jaw-translate` converts JAW ↔ real code in either direction (using `jaw-cli export` for comment-embedding); `jaw-review` lints semantic gaps the parser/LSP don't catch; `jaw-and-implement` produces JAW + a working implementation as one interleaved file.
- Skills reference `jaw-grammar.md`, `docs/glossary.md`, and `docs/examples/*.jaw` by path rather than duplicating spec content — they stay in sync with the spec automatically.

## Test plan

- [ ] In a fresh Claude Code session at the repo root, ask "write JAW for binary search on a sorted vector" — verify `jaw-author` fires and the output uses U+2014 em dashes, title-case function names, bracketed variable refs.
- [ ] Ask "implement docs/examples/example-func.jaw in Python" — verify `jaw-translate` produces real Python, not comments.
- [ ] Ask "embed docs/examples/example-func.jaw as comments in Rust" — verify it shells out to `jaw export --lang rust`.
- [ ] Create a temp `.jaw` file with a call to undefined `/Foo[]` and an unused `[X] —` declaration; ask "review this jaw file" — verify both are flagged with file:line.
- [ ] Ask "write JAW and Python for binary search" — verify `jaw-and-implement` produces a single Python block with JAW interleaved as `#` comments above each step (not two separate fenced blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)