### PR TITLE
Stop coloring bare words in assignment values as constants

### DIFF
--- a/editors/vscode/syntaxes/jaw.tmLanguage.json
+++ b/editors/vscode/syntaxes/jaw.tmLanguage.json
@@ -346,7 +346,7 @@
       }
     },
     "number-literal": {
-      "match": "-?\\d+(\\.\\d+)?",
+      "match": "(?<![\\w.])-?\\d+(\\.\\d+)?(?![\\w.])",
       "name": "constant.numeric.jaw"
     }
   }

--- a/editors/vscode/syntaxes/jaw.tmLanguage.json
+++ b/editors/vscode/syntaxes/jaw.tmLanguage.json
@@ -218,7 +218,6 @@
         },
         "4": { "name": "keyword.operator.jaw" },
         "5": {
-          "name": "constant.other.value.jaw",
           "patterns": [
             { "include": "#function-reference" },
             { "include": "#variable-reference" },
@@ -258,7 +257,6 @@
         },
         "4": { "name": "keyword.operator.jaw" },
         "5": {
-          "name": "constant.other.value.jaw",
           "patterns": [
             { "include": "#function-reference" },
             { "include": "#variable-reference" },


### PR DESCRIPTION
The inline-assignment value capture applied a blanket constant.other.value.jaw
scope to the entire right-hand side. Unrecognized bare words (e.g. Length in
[F]: Forward end = Length[ [V] ] - 1) inherited that scope and were highlighted
as constants. Drop the blanket name so bare text falls back to plaintext while
real tokens (numbers, variable/function refs, operators) keep their scopes.